### PR TITLE
Fix redis image tag

### DIFF
--- a/standalone/redis.yaml
+++ b/standalone/redis.yaml
@@ -297,7 +297,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
-          image: docker.io/bitnamilegacy/redis:6.2.4-debian-10-r13
+          image: docker.io/bitnamilegacy/redis:6.2.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001


### PR DESCRIPTION
The `-debian-10-r13` is not available
